### PR TITLE
corrected typo

### DIFF
--- a/docs/users/reference/noteProcessors/tuningProcessor.md
+++ b/docs/users/reference/noteProcessors/tuningProcessor.md
@@ -5,7 +5,7 @@
 Parameters: pfield, baseFrequency, scalaFile
 
 Converts Blue PCH notation to frequency according to scale values in a
-Scala scale file. The scale will default to 12TET wheen TuningProcessor
+Scala scale file. The scale will default to 12TET when TuningProcessor
 is initially created. The file selector for choosing a Scala .scl file
 will default to user's .blue directory, under the scl subdirectory. It
 is advised that users download the 3000+ scale archive from the Scala


### PR DESCRIPTION
changed:
'The scale will default to 12TET wheen TuningProcessor is initially created.'
to
'The scale will default to 12TET when TuningProcessor is initially created.